### PR TITLE
ノート詳細画面のアンダーバーの実装

### DIFF
--- a/app/assets/javascripts/under-bar.js
+++ b/app/assets/javascripts/under-bar.js
@@ -1,0 +1,13 @@
+$(document).on('turbolinks:load', function(){
+  $(window).scroll(function() {
+    if ($(this).scrollTop() > 100) {
+      $('.under-bar').stop().animate({
+        'bottom': '-68px'
+      }, 100 , 'linear');
+    } else {
+      $('.under-bar').stop().animate({
+        'bottom': '0px'
+      }, 100 , 'linear');
+    }
+  });
+});

--- a/app/assets/stylesheets/_under-bar.scss
+++ b/app/assets/stylesheets/_under-bar.scss
@@ -2,7 +2,7 @@
   position: fixed;
   z-index: 10;
   left: 0;
-  bottom: 0;
+  bottom: 0px;
   width: 100%;
   background-color: #ffffff;
   border-top: 1px solid rgba(0,0,0,0.05);

--- a/app/assets/stylesheets/_under-bar.scss
+++ b/app/assets/stylesheets/_under-bar.scss
@@ -1,0 +1,65 @@
+.under-bar {
+  position: fixed;
+  z-index: 10;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  background-color: #ffffff;
+  border-top: 1px solid rgba(0,0,0,0.05);
+
+  &__inner {
+    width: 620px;
+    margin-left: auto;
+    margin-right: auto;
+    padding-top: 4px;
+    padding-bottom: 4px;
+
+    .under-bar__actions {
+      height: 60px;
+      color: #A8ABB1;
+
+      &__left {
+        float: left;
+        line-height: 60px;
+
+        ul {
+
+          li {
+            display: inline-block;
+            font-size: 20px;
+            width: 56px;
+            height: 56px;
+            line-height: 56px;
+            text-align: center;
+
+            .fa-heart {
+              color: $like-color;
+            }
+
+            span {
+              margin-left: 4px;
+              color: $like-color;
+              font-size: 16px;
+              line-height: 56px;
+            }
+          }
+        }
+      }
+
+      &__right {
+        float: right;
+        line-height: 60px;
+        ul {
+          li {
+            display: inline-block;
+            font-size: 20px;
+            width: 56px;
+            height: 56px;
+            line-height: 56px;
+            text-align: center;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,3 +22,4 @@
 @import "./helps-index";
 @import "./article-modal";
 @import "./follow-index";
+@import "./under-bar";

--- a/app/views/notes/_under-bar.html.haml
+++ b/app/views/notes/_under-bar.html.haml
@@ -1,0 +1,27 @@
+.under-bar
+  .under-bar__inner
+    .under-bar__actions
+      .under-bar__actions__left
+        %ul
+          %li
+            %i.far.fa-heart
+            %span 5
+          %li
+            = link_to "" do
+              %i.far.fa-plus-square
+      .under-bar__actions__right
+        %ul
+          %li
+            = link_to "" do
+              %i.fab.fa-twitter
+          %li
+            = link_to "" do
+              %i.fab.fa-facebook-f
+          %li
+            = link_to "" do
+              %i.fas.fa-bold
+          %li
+            = link_to "" do
+              %i.fab.fa-line
+
+

--- a/app/views/notes/show.html.haml
+++ b/app/views/notes/show.html.haml
@@ -123,6 +123,7 @@
     %form.comments__form__content
       %textarea.comments__form__content__text
       %input{type: "submit", class: "comments__form__content__submit"}
+= render 'under-bar'
 .footer
   %ul.footer__list
     %li.footer__list__item


### PR DESCRIPTION
#WHAT
下にスクロールするとページ下部のアンダーバーが消え、上までスクロールすると再びアンダバーが表示されるようにする。
(※ノート詳細画面は仮置きのため、いいね数等も仮置きになっています)

#WHY
UX向上のため